### PR TITLE
Fix forgotten awaits in app.crud.base.CRUDBase

### DIFF
--- a/users/app/crud/base.py
+++ b/users/app/crud/base.py
@@ -49,7 +49,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         db_obj: Optional[ModelType] = None,
         **kwargs
     ) -> Optional[ModelType]:
-        db_obj = db_obj or self.get(session, **kwargs)
+        db_obj = db_obj or await self.get(session, **kwargs)
         if db_obj is not None:
             obj_data = db_obj.dict()
             if isinstance(obj_in, dict):
@@ -66,7 +66,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     async def delete(
         self, session: AsyncSession, *args, db_obj: Optional[ModelType] = None, **kwargs
     ) -> ModelType:
-        db_obj = db_obj or self.get(session, *args, **kwargs)
+        db_obj = db_obj or await self.get(session, *args, **kwargs)
         await session.delete(db_obj)
         await session.commit()
         return db_obj


### PR DESCRIPTION
Resolves #61 

Hi,

thank you for very informative template project for starting out with FastAPI, helps a ton.

I have noticed that you have 2 forgotten `await`s in the `CRUDBase` class. This quick PR fixes that.

Cheers,
Libor