### PR TITLE
jsonable_encoder() is not working with many to many

### DIFF
--- a/users/app/crud/base.py
+++ b/users/app/crud/base.py
@@ -17,7 +17,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     async def create(
         self, session: AsyncSession, obj_in: CreateSchemaType
     ) -> ModelType:
-        obj_in_data = jsonable_encoder(obj_in)
+        obj_in_data = dict(obj_in)
         db_obj = self._model(**obj_in_data)
         session.add(db_obj)
         await session.commit()

--- a/users/app/crud/base.py
+++ b/users/app/crud/base.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
-from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
With a many to many complexe list relation jsonnable_encoder() will not work with session.add()
the data part of the obj from jsonnable_encoder(obj_in) will have the same structure as dict(obj_in) but when you pass it at session.add(obj_in) it will raise a model mapping error wich is a deep rabbit hole since it is not the problem at all

It will not affect the beaviour of this project but in futur modification or if someone use it like me for a diferent use case it will


to recreate the behaviour you can use this sample of sqlamchemy models and relations:

```
class Permission(Base):
    __tablename__ = 'permission'
    id = Column(Integer, autoincrement=True, primary_key=True)
    name = Column(String(100), nullable=False, unique=True)

    roles = relationship("Role", secondary=role_permission, backref=backref('permissions', lazy=True), lazy='subquery')
```

```
class Role(Base):
    __tablename__ = 'role'
    id = Column(Integer, primary_key=True, autoincrement=True)
    name = Column(String(100), nullable=False, unique=True)
```

```
role_permission = Table('role_permission', Base.metadata,
                        Column('permission_id', ForeignKey('permission.id'), primary_key=True),
                        Column('role_id', ForeignKey('role.id'), primary_key=True)
                        )
```