### PR TITLE
Add aioredis in requirements.txt

### DIFF
--- a/users/requirements.txt
+++ b/users/requirements.txt
@@ -21,3 +21,4 @@ black==20.8b1
 mypy==0.812
 httpx==0.17.1
 asgi-lifespan==1.0.1
+aioredis==1.3.1


### PR DESCRIPTION
Without aioredis, **ImportError: cannot import name 'MultiExecError' from 'aioredis'** occurs